### PR TITLE
upgrade deps for latest node and bump version to 0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unix-socket-credentials",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Get the uid, gid and pid of a client that connects to your unix socket server",
   "main": "index.js",
   "scripts": {
@@ -21,12 +21,12 @@
   "author": "spion",
   "license": "MIT",
   "dependencies": {
-    "ref": "~0.1.3",
-    "ffi": "~1.2.5",
-    "ref-struct": "0.0.5"
+    "ffi": "~2.2.0",
+    "ref": "^1.3.5",
+    "ref-struct": "^1.1.0"
   },
   "devDependencies": {
-    "tap": "~0.4.3"
+    "tap": "~11.1.4"
   },
   "readmeFilename": "README.md",
   "directories": {


### PR DESCRIPTION
Needed to compile with latest node lts, tests are passing OK, unsure if still working with previous nodes hence version bump from 0.1->0.2